### PR TITLE
[hive][audit_log] change hive audit log format to be compatible with flink-based rh event logging pipeline

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -66,6 +66,8 @@ import java.util.regex.Pattern;
 import javax.jdo.JDOException;
 
 import com.codahale.metrics.Counter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 
 import org.apache.commons.cli.OptionBuilder;
@@ -351,7 +353,13 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         address = "unknown-ip-addr";
       }
 
-      auditLog.info("ugi={}	ip={}	cmd={}	", ugi.getUserName(), address, cmd);
+      ObjectMapper mapper = new ObjectMapper();
+      ObjectNode metricNode = mapper.createObjectNode();
+      metricNode.put("ugi", ugi.getUserName());
+      metricNode.put("ip", address);
+      metricNode.put("cmd", cmd);
+      auditLog.info(metricNode.toString());
+      // auditLog.info("ugi={}	ip={}	cmd={}	", ugi.getUserName(), address, cmd);
     }
 
     private static String getIPAddress() {


### PR DESCRIPTION
Change hive audit log format(unformatted ->json) to be compatible with flink-based rh event logging pipeline